### PR TITLE
Add security URL

### DIFF
--- a/lib/aptible/rails.rb
+++ b/lib/aptible/rails.rb
@@ -14,6 +14,8 @@ module Aptible
                               'https://policy.aptible.com'
     default_risk_root_url = ENV['APTIBLE_RISK_ROOT_URL'] ||
                             'https://risk.aptible.com'
+    default_security_root_url = ENV['APTIBLE_SECURITY_ROOT_URL'] ||
+                            'https://security.aptible.com'
 
     with_configuration do
       # Where users will be redirected on
@@ -31,6 +33,8 @@ module Aptible
                             default: default_policy_root_url
       has :risk_root_url, classes: [String],
                           default: default_risk_root_url
+      has :security_root_url, classes: [String],
+                              default: default_security_root_url
     end
   end
 end

--- a/lib/aptible/rails/url_helper.rb
+++ b/lib/aptible/rails/url_helper.rb
@@ -41,7 +41,8 @@ module Aptible
                      aptible_config.marketing_root_url + '/privacy'
         register_url :risk_url, aptible_config.risk_root_url
         register_url :roles_url, aptible_config.dashboard_root_url + '/roles'
-        register_url :security_url,
+        register_url :security_url, aptible_config.security_root_url
+        register_url :security_marketing_url,
                      aptible_config.marketing_root_url + '/security'
         # Statuspage.io requires a business-tier plan for SSL
         register_url :status_url, 'http://status.aptible.com/'

--- a/lib/aptible/rails/version.rb
+++ b/lib/aptible/rails/version.rb
@@ -1,5 +1,5 @@
 module Aptible
   module Rails
-    VERSION = '0.1.11'
+    VERSION = '0.1.12'
   end
 end


### PR DESCRIPTION
Putting security interviews in policy or risk was getting messy. Spinning up a separate app, which will eventually be a security dashboard and validator. For now, it will generate application security interviews.
