### PR TITLE
Fix for broken org switcher

### DIFF
--- a/lib/aptible/rails/controller.rb
+++ b/lib/aptible/rails/controller.rb
@@ -28,11 +28,12 @@ module Aptible
         return @current_organization if @current_organization
         url = read_shared_cookie(:organization_url)
         @current_organization = Aptible::Auth::Organization.find_by_url(
-          url, token: session_token
-        ) if url
+                                url, token: session_token) if url
+        @current_organization ||= default_organization
+
       rescue HyperResource::ClientError => e
         raise e unless e.body['code'] == 403
-        set_default_organization
+        @current_organization = default_organization
       end
 
       def current_organization=(organization)
@@ -43,8 +44,7 @@ module Aptible
         token_subject || session_subject
       end
 
-      # before_action :set_default_organization
-      def set_default_organization
+      def default_organization
         return @current_organization if @current_organization
         orgs = Aptible::Auth::Organization.all(token: session_token)
         self.current_organization = orgs.first if orgs.any?

--- a/lib/aptible/rails/decorators/resource_decorator.rb
+++ b/lib/aptible/rails/decorators/resource_decorator.rb
@@ -17,4 +17,10 @@ class ResourceDecorator < ApplicationDecorator
     return nil unless object.last_operation
     @last_operation ||= OperationDecorator.decorate(object.last_operation)
   end
+
+  def operation_count
+    garner.bind(h.controller.session_token).bind(object) do
+      object.operations.count
+    end
+  end
 end

--- a/lib/aptible/rails/version.rb
+++ b/lib/aptible/rails/version.rb
@@ -1,5 +1,5 @@
 module Aptible
   module Rails
-    VERSION = '0.6.8'
+    VERSION = '0.6.9'
   end
 end


### PR DESCRIPTION
Because of https://github.com/aptible/dashboard.aptible.com/pull/349, `set_default_organization` is no longer needed as a before filter and instead is just a fallback for `current_organization`.
