### PR TITLE
Fallback last_operation if it is not embedded

### DIFF
--- a/lib/aptible/rails/decorators/resource_decorator.rb
+++ b/lib/aptible/rails/decorators/resource_decorator.rb
@@ -14,8 +14,15 @@ class ResourceDecorator < ApplicationDecorator
   end
 
   def last_operation
-    return nil unless object.last_operation
-    @last_operation ||= OperationDecorator.decorate(object.last_operation)
+    return @last_operation if @last_operation
+    if object.respond_to?(:last_operation)
+      operation = object.last_operation
+    else
+      operation = object.operations.last
+    end
+
+    return nil unless operation
+    @last_operation = OperationDecorator.decorate(operation)
   end
 
   def operation_count

--- a/lib/aptible/rails/version.rb
+++ b/lib/aptible/rails/version.rb
@@ -1,5 +1,5 @@
 module Aptible
   module Rails
-    VERSION = '0.6.9'
+    VERSION = '0.6.10'
   end
 end


### PR DESCRIPTION
This adds some backwards compatibility incase `last_operation` is not available on the resource.
