### PR TITLE
Expired documents should be excluded from generating status

### DIFF
--- a/lib/aptible/rails/decorators/criterion_alert_decorator.rb
+++ b/lib/aptible/rails/decorators/criterion_alert_decorator.rb
@@ -40,11 +40,15 @@ class CriterionAlertDecorator < Draper::Decorator
   end
 
   def completed_users
-    object.documents.map { |d| d.links['user'].href }.uniq
+    valid_documents.map { |d| d.links['user'].href }.uniq
   end
 
   def completed_apps
-    object.documents.map { |d| d.links['app'].href }.uniq
+    valid_documents.map { |d| d.links['app'].href }.uniq
+  end
+
+  def valid_documents
+    object.documents.select { |d| d.expires_at.nil? || d.expires_at > Time.now }
   end
 
   def all_users

--- a/lib/aptible/rails/decorators/user_decorator.rb
+++ b/lib/aptible/rails/decorators/user_decorator.rb
@@ -60,7 +60,7 @@ class UserDecorator < ApplicationDecorator
 
   def training_logs
     training_criterion.documents.select do |doc|
-      doc.links['user'].href == object.href
+      doc.expires_at > Time.now && doc.links['user'].href == object.href
     end
   end
 


### PR DESCRIPTION
We currently show a user as trained, even if their training is expired.  This is fixed in Sheriff, but because most users still refer to the legacy dashboard, we should fix here.