### PR TITLE
Eliminate deprecated methods

### DIFF
--- a/lib/aptible/rails/decorators/role_decorator.rb
+++ b/lib/aptible/rails/decorators/role_decorator.rb
@@ -1,9 +1,4 @@
 class RoleDecorator < ApplicationDecorator
-  def can?(scope, account)
-    role_scopes = account_permissions(account).map(&:scope)
-    role_scopes.include?('manage') || role_scopes.include?(scope)
-  end
-
   def has?(scope, account)
     account_permissions(account).map(&:scope).include?(scope)
   end

--- a/lib/aptible/rails/decorators/user_decorator.rb
+++ b/lib/aptible/rails/decorators/user_decorator.rb
@@ -1,13 +1,4 @@
 class UserDecorator < ApplicationDecorator
-  def can?(scope, account)
-    # Attempt to use current_organization context before loading via HTTP
-    organization = context[:current_organization] || account.organization
-
-    return true if object.can_manage?(organization)
-    user_scopes = account_permissions(account).map(&:scope)
-    user_scopes.include?('manage') || user_scopes.include?(scope)
-  end
-
   def cached_organizations
     garner
       .bind(h.controller.session_token)


### PR DESCRIPTION
I don't believe these methods are used in compliance.aptible.com, but @gib or @sandersonet can let me know otherwise.
